### PR TITLE
Fix : Alembic migration for scheduled query from older to newer version

### DIFF
--- a/migrations/versions/640888ce445d_.py
+++ b/migrations/versions/640888ce445d_.py
@@ -69,7 +69,7 @@ def upgrade():
                 schedule_json["interval"] = 86400
                 schedule_json["time"] = query.old_schedule
             else:
-                schedule_json["interval"] = query.old_schedule
+                schedule_json["interval"] = int(query.old_schedule)
 
         conn.execute(
             queries.update()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

Fixes the alembic migration of query schedules, so that older versions like v4 can also migrate to newer version

## Related Tickets & Documents

Fixes [#4708](https://github.com/getredash/redash/issues/4708)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
